### PR TITLE
Yield the context of each statement from store.triples() instead of the query context

### DIFF
--- a/rdflib_django/store.py
+++ b/rdflib_django/store.py
@@ -191,7 +191,9 @@ class DjangoStore(rdflib.store.Store):
         for qs in query_sets:
             for statement in qs:
                 triple = statement.as_triple()
-                yield triple, context
+                cg_id = statement.context.identifier
+                cg = rdflib.Graph(store=self, identifier=cg_id)
+                yield triple, [cg]  # rdflib expects an iterator
 
     def __len__(self, context=None):
         """


### PR DESCRIPTION
I was running into an error in a project that uses rdflib-django3:

    > /$REDACTED/site-packages/rdflib/graph.py(1419)quads()
    -> for ctx in cg:
    (Pdb) l
    1414            """Iterate over all the quads in the entire conjunctive graph"""
    1415    
    1416            s,p,o,c = self._spoc(triple_or_quad)
    1417    
    1418            for (s, p, o), cg in self.store.triples((s, p, o), context=c):
    1419 ->             for ctx in cg:
    1420                    yield s, p, o, ctx
    1421    
    (Pdb) p cg
    None
    (Pdb) n
    TypeError: 'NoneType' object is not iterable

This was caused by `rdflib_django.store.triples()` returning the `context` keyword argument as the second element of the returned pair, instead of an iterator over context graphs of the yielded triple as rdflib expects. This pull requests should solve this issue; at least it does for my project.

I have not tried running the tests, as it was not clear to me how to do this. If anything needs fixing, please let me know.