### PR TITLE
Fixed editing of Namespace and of BNode value in statements.

### DIFF
--- a/rdflib_django/admin.py
+++ b/rdflib_django/admin.py
@@ -1,6 +1,8 @@
 """
 Defines admin options for this RDFlib implementation.
 """
+from rdflib.term import BNode
+
 from django.contrib import admin
 from django.contrib.admin.widgets import AdminTextareaWidget
 
@@ -48,7 +50,11 @@ class AdminURIWidget(AdminTextareaWidget):
         """
         Return a value as it should appear when rendered in a form.
         """
-        return fields.serialize_uri(value)
+        # test below shouldn't be necessary if code in fields module was more coherent
+        if isinstance(value, BNode):
+            return fields.serialize_uri(value)
+        else:
+            return value
 
 
 @admin.register(models.URIStatement)

--- a/rdflib_django/forms.py
+++ b/rdflib_django/forms.py
@@ -19,20 +19,10 @@ class NamespaceForm(forms.ModelForm):
         model = models.NamespaceModel
         fields = ('prefix', 'uri')
 
-    def __init__(self, *args, **kwargs):
-        super(NamespaceForm, self).__init__(*args, **kwargs)
-
-        if self.instance.fixed:
-            self.fields['prefix'].widget.attrs['readonly'] = True
-            self.fields['uri'].widget.attrs['readonly'] = True
-
     def clean_prefix(self):
         """
         Validates the prefix
         """
-        if self.instance.fixed:
-            return self.instance.prefix
-
         prefix = self.cleaned_data['prefix']
         if not namespace.is_ncname(prefix):
             raise forms.ValidationError("This is an invalid prefix")
@@ -43,9 +33,6 @@ class NamespaceForm(forms.ModelForm):
         """
         Validates the URI
         """
-        if self.instance.fixed:
-            return self.instance.uri
-
         uri = self.cleaned_data['uri']
         # todo: URI validation
         return uri


### PR DESCRIPTION
In the forms module I've removed tests referring a no more existing "fixed" attribute, which prevented _Namespace_ editing.
In the admin module fixed the editing of _BNode_ values in the _URIField_ slots of URIStatement and LiteralStatement.